### PR TITLE
manifests: set shared cpus explicitly

### DIFF
--- a/pkg/manifests/yamls/daemonset.yaml
+++ b/pkg/manifests/yamls/daemonset.yaml
@@ -21,7 +21,6 @@ spec:
             args:
               - --name=mixedcpus
               - --idx=99
-              - --mutual-cpus=0,40
               - --v=4
               - --alsologtostderr
             resources:

--- a/test/e2e/config/config.go
+++ b/test/e2e/config/config.go
@@ -1,0 +1,11 @@
+package config
+
+import "os"
+
+func SharedCPUs() string {
+	cpus, ok := os.LookupEnv("E2E_SHARED_CPUS")
+	if !ok {
+		return ""
+	}
+	return cpus
+}

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -68,15 +68,6 @@ func TestE2e(t *testing.T) {
 
 }
 
-// TODO make it possible to read directly from DaemonSet
-func GetSharedCPUs() string {
-	cpus, ok := os.LookupEnv("E2E_SHARED_CPUS")
-	if !ok {
-		return ""
-	}
-	return cpus
-}
-
 func GetNamespaceName() string {
 	cpus, ok := os.LookupEnv("E2E_NAMESPACE")
 	if !ok {

--- a/test/e2e/infrastructure/infrastructure.go
+++ b/test/e2e/infrastructure/infrastructure.go
@@ -18,6 +18,7 @@ import (
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform"
 	"github.com/k8stopologyawareschedwg/deployer/pkg/deployer/platform/detect"
 	"github.com/openshift-kni/mixed-cpu-node-plugin/pkg/manifests"
+	e2econfig "github.com/openshift-kni/mixed-cpu-node-plugin/test/e2e/config"
 	"github.com/openshift-kni/mixed-cpu-node-plugin/test/e2e/wait"
 	machineconfigv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 )
@@ -84,7 +85,7 @@ func setup(ctx context.Context, c client.Client, ns string) error {
 		return err
 	}
 
-	mf, err := manifests.Get(ns)
+	mf, err := manifests.Get(ns, e2econfig.SharedCPUs())
 	if err != nil {
 		return err
 	}
@@ -113,7 +114,7 @@ func setup(ctx context.Context, c client.Client, ns string) error {
 }
 
 func teardown(ctx context.Context, c client.Client, ns string) error {
-	mf, err := manifests.Get(ns)
+	mf, err := manifests.Get(ns, e2econfig.SharedCPUs())
 	if err != nil {
 		return err
 	}

--- a/test/e2e/mixedcpus_test.go
+++ b/test/e2e/mixedcpus_test.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openshift-kni/mixed-cpu-node-plugin/pkg/deviceplugin"
+	e2econfig "github.com/openshift-kni/mixed-cpu-node-plugin/test/e2e/config"
 	e2ecpuset "github.com/openshift-kni/mixed-cpu-node-plugin/test/e2e/cpuset"
 	"github.com/openshift-kni/mixed-cpu-node-plugin/test/e2e/pods"
 )
@@ -86,7 +87,7 @@ var _ = Describe("Mixedcpus", func() {
 			cpus, err := pods.GetAllowedCPUs(fixture.K8SCli, pod)
 			Expect(err).ToNot(HaveOccurred())
 
-			sharedCpus := GetSharedCPUs()
+			sharedCpus := e2econfig.SharedCPUs()
 			Expect(sharedCpus).ToNot(BeEmpty())
 			sharedCpusSet := e2ecpuset.MustParse(sharedCpus)
 


### PR DESCRIPTION
Having a default shared cpus is a bad idea,
because we cannot predict the system cpu layout and
we don't know which are the reserved cpus that we can derive
the shared cpu from.
    
Instead we should ask for the shared cpus explicitly from the user.
    
Signed-off-by: Talor Itzhak <titzhak@redhat.com>