### PR TITLE
build: fixing image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM golang
+FROM golang:1.20
 COPY build/bin/mixedcpu /bin/mixedcpu
 ENTRYPOINT [ "/bin/mixedcpu" ]

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ COVERAGE_PATH := $(BUILD_PATH)/coverage
 PLUGIN = $(BIN_PATH)/mixedcpu
 
 COMMONENVVAR = GOOS=linux GOARCH=amd64
-BUILDENVVAR = CGO_ENABLED=1
+BUILDENVVAR = CGO_ENABLED=0
 RUNTIME ?= docker
 REPOOWNER ?= openshift-kni
 IMAGENAME ?= mixed-cpu-node-plugin
@@ -83,7 +83,7 @@ mkdir:
 	mkdir -p build/bin || true
 
 build-plugin: mkdir
-	$(GO_BUILD) -o $(PLUGIN) ./cmd/main.go
+	$(COMMONENVVAR) $(BUILDENVVAR) $(GO_BUILD) -o $(PLUGIN) ./cmd/main.go
 
 build-check:
 	$(Q)$(GO_BUILD) -v $(GO_MODULES)

--- a/deployment/kustomize/base/daemonset.yaml
+++ b/deployment/kustomize/base/daemonset.yaml
@@ -13,10 +13,10 @@ spec:
     spec:
       containers:
           - name: mixedcpus-plugin
-            image: quay.io/titzhak/mixedcpus
+            image: quay.io/titzhak/mixed-cpu-node-plugin
             imagePullPolicy: Always
             command:
-              - /bin/mixedcpus
+              - /bin/mixedcpu
             args:
               - --name=mixedcpus
               - --idx=99


### PR DESCRIPTION
Due to recent changes, the plugin image build has failed. The following changes has been added:
1. Fixing the ENTRYPOINT in the Dockerfile
2. Pin golang to 1.20
3. Running the go build command with the right arguments