### PR TITLE
device-plugin: support infinite amount of devices

### DIFF
--- a/internal/deployments/deployments.go
+++ b/internal/deployments/deployments.go
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package deployments
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+
+	"github.com/openshift-kni/mixed-cpu-node-plugin/internal/pods"
+)
+
+type Options func(deployment *appsv1.Deployment)
+
+func Make(name, namespace string, opts ...Options) *appsv1.Deployment {
+	pod := pods.Make(name+"pod", namespace)
+	labelsMap := map[string]string{"name": name}
+	dp := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: labelsMap,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: labelsMap,
+				},
+				Spec: pod.Spec,
+			},
+		},
+	}
+
+	for _, opt := range opts {
+		opt(dp)
+	}
+	return dp
+}
+
+func WithReplicas(replicas int) func(dp *appsv1.Deployment) {
+	return func(dp *appsv1.Deployment) {
+		dp.Spec.Replicas = pointer.Int32(int32(replicas))
+	}
+}
+
+func WithPodSpec(spec corev1.PodSpec) func(dp *appsv1.Deployment) {
+	return func(dp *appsv1.Deployment) {
+		dp.Spec.Template.Spec = spec
+	}
+
+}

--- a/internal/wait/wait.go
+++ b/internal/wait/wait.go
@@ -74,7 +74,7 @@ func ForDSReady(ctx context.Context, c client.Client, key client.ObjectKey) erro
 
 func ForDeploymentReady(ctx context.Context, c client.Client, key client.ObjectKey) error {
 	dp := &appsv1.Deployment{}
-	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(ctx, 10*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
 		err := c.Get(ctx, key, dp)
 		if err != nil {
 			return false, fmt.Errorf("failed to get deployment %q; %w", key.String(), err)

--- a/pkg/deviceplugin/implementation.go
+++ b/pkg/deviceplugin/implementation.go
@@ -18,6 +18,7 @@ package deviceplugin
 
 import (
 	"context"
+	"strconv"
 
 	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
@@ -28,28 +29,70 @@ import (
 	"github.com/golang/glog"
 )
 
+const (
+	initialDevicesQuantity = 15
+	// the maximum pods per node are 256,
+	// so this number should be more than enough
+	devicesLimit = 1024
+)
+
+type message struct {
+	requestedDevices int
+}
+
 type pluginImp struct {
-	mutualCpus *cpuset.CPUSet
+	mutualCpus       *cpuset.CPUSet
+	update           chan message
+	allocatedDevices int
 }
 
 func (p pluginImp) ListAndWatch(empty *pluginapi.Empty, server pluginapi.DevicePlugin_ListAndWatchServer) error {
-	devs := MakeMutualCpusDevices()
-	glog.V(4).Infof("ListAndWatch respond with: %+v", devs)
-	if err := server.Send(&pluginapi.ListAndWatchResponse{Devices: devs}); err != nil {
+	var devID int
+	devs := makeDevices(initialDevicesQuantity, devID)
+	devID += len(devs)
+
+	resp := &pluginapi.ListAndWatchResponse{Devices: devs}
+	glog.V(4).Infof("ListAndWatch respond with: %+v", resp)
+	if err := server.Send(resp); err != nil {
 		return err
 	}
-	// do not return, we need to keep the connection open
-	select {}
+	// never return, keep the connection open
+	for {
+		u := <-p.update
+		p.allocatedDevices += u.requestedDevices
+		if p.allocatedDevices > devicesLimit {
+			glog.V(2).Infof("Warning: device limit has reached. can not populate more %q makeDevices", MutualCPUDeviceName)
+			continue
+		}
+		// check if more makeDevices are needed
+		if p.allocatedDevices >= len(devs) {
+			newDevs := makeDevices(initialDevicesQuantity, devID)
+			devID += len(newDevs)
+			devs = append(devs, newDevs...)
+
+			resp = &pluginapi.ListAndWatchResponse{Devices: devs}
+			err := server.Send(resp)
+			glog.V(4).Infof("ListAndWatch update respond with: %+v", resp)
+			if err != nil {
+				return err
+			}
+		}
+	}
 }
 
 func (p pluginImp) Allocate(ctx context.Context, request *pluginapi.AllocateRequest) (*pluginapi.AllocateResponse, error) {
-	return &pluginapi.AllocateResponse{
-		ContainerResponses: []*pluginapi.ContainerAllocateResponse{
-			{
-				Envs: map[string]string{"OPENSHIFT_MUTUAL_CPUS": p.mutualCpus.String()},
-			},
-		},
-	}, nil
+	response := &pluginapi.AllocateResponse{}
+
+	p.update <- message{requestedDevices: len(request.ContainerRequests)}
+
+	glog.V(4).Infof("Allocate called with %+v", request)
+	for range request.ContainerRequests {
+		containerResponse := &pluginapi.ContainerAllocateResponse{
+			Envs: map[string]string{"OPENSHIFT_MUTUAL_CPUS": p.mutualCpus.String()},
+		}
+		response.ContainerResponses = append(response.ContainerResponses, containerResponse)
+	}
+	return response, nil
 }
 
 func (p pluginImp) GetDevicePluginOptions(ctx context.Context, empty *pluginapi.Empty) (*pluginapi.DevicePluginOptions, error) {
@@ -62,4 +105,16 @@ func (p pluginImp) GetPreferredAllocation(ctx context.Context, request *pluginap
 
 func (p pluginImp) PreStartContainer(ctx context.Context, request *pluginapi.PreStartContainerRequest) (*pluginapi.PreStartContainerResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method PreStartContainer not implemented")
+}
+
+func makeDevices(count, devID int) []*pluginapi.Device {
+	var devs []*pluginapi.Device
+	for i := 0; i < count; i++ {
+		dev := &pluginapi.Device{
+			ID:     strconv.Itoa(devID + i),
+			Health: pluginapi.Healthy,
+		}
+		devs = append(devs, dev)
+	}
+	return devs
 }


### PR DESCRIPTION
Since shared cpu devices are not an actual devices, therefore we want to support an infinite amount of them.

This patch tracks the amount of allocated shared cpu devices and populates more devices if the amount of shared devices on the node has been exhausted.