### PR TITLE
ci: e2e: small fixes for stabilizing the ci

### DIFF
--- a/internal/wait/wait.go
+++ b/internal/wait/wait.go
@@ -90,9 +90,10 @@ func ForDeploymentReady(ctx context.Context, c client.Client, key client.ObjectK
 	})
 
 	if err != nil {
-		ownedPods, err := pods.OwnedByDeployment(ctx, c, dp, &client.ListOptions{})
-		if err != nil {
-			return err
+		// do not override the original error
+		ownedPods, e := pods.OwnedByDeployment(ctx, c, dp, &client.ListOptions{})
+		if e != nil {
+			return e
 		}
 		return fmt.Errorf("failed wait for deployment %q to be ready. only %d/%d are ready;\n pods status: %s; %w",
 			key.String(), dp.Status.ReadyReplicas, dp.Status.Replicas, pods.PrintStatus(ownedPods), err)

--- a/test/e2e/infrastructure/yamls/kubeletconfig.yaml
+++ b/test/e2e/infrastructure/yamls/kubeletconfig.yaml
@@ -8,4 +8,4 @@ spec:
       pools.operator.machineconfiguration.openshift.io/worker: ""
   kubeletConfig:
     cpuManagerPolicy: "static"
-    reservedSystemCPUs: "0,1"
+    reservedSystemCPUs: "0"


### PR DESCRIPTION
* Decreasing reservedSystemCPU pool -
On the ci we only have 4 CPUs so let's squeeze the reservedSystemCPU to minimum
and leave enough CPUs for the test itself.

* do not override error in error flow