### PR TITLE
manifests: accept optional parameter functions

### DIFF
--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -111,6 +111,18 @@ func WithNamespace(ns string) func(mf *Manifests) {
 		mf.Role.Namespace = ns
 		mf.RB.Namespace = ns
 		mf.SA.Namespace = ns
+		// SCC is cluster scoped
+	}
+}
+
+func WithName(name string) func(mf *Manifests) {
+	return func(mf *Manifests) {
+		mf.DS.Name = name
+		mf.Role.Name = name
+		mf.SA.Name = name
+		mf.RB.Name = name
+		mf.RB.RoleRef.Name = mf.Role.Name
+		mf.SCC.Name = name
 	}
 }
 

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -52,7 +52,7 @@ func TestSetSharedCPUs(t *testing.T) {
 		},
 	}
 	for _, tc := range tcs {
-		mf, err := Get("", tc.cpus)
+		mf, err := Get(tc.cpus)
 		if !tc.IsError && err != nil {
 			t.Errorf("failed to get manifests %v", err)
 		}
@@ -85,7 +85,7 @@ func TestSetSharedCPUs(t *testing.T) {
 }
 
 func TestGet(t *testing.T) {
-	mf, err := Get("unit-test-ns", "0-3,5")
+	mf, err := Get("0-3,5", WithNewNamespace("unit-test-ns"))
 	if err != nil {
 		t.Errorf("failed to get manifests %v", err)
 	}
@@ -111,11 +111,25 @@ func TestGet(t *testing.T) {
 		t.Errorf("wrong namespace name %q", mf.NS.Name)
 	}
 
-	mf, err = Get("", "1,2,4")
+	mf, err = Get("1,2,4", WithNamespace("unit-test-12"))
 	if err != nil {
 		t.Errorf("failed to get manifests %v", err)
 	}
 	if !reflect.DeepEqual(mf.NS, corev1.Namespace{}) {
-		t.Errorf("should have an empty namespace when specified ns is \"\"")
+		t.Errorf("should have an empty namespace when WithNamespace called")
+	}
+	if mf.DS.Namespace != "unit-test-12" {
+		t.Errorf("%q object namespace not set", mf.DS.Kind)
+	}
+
+	mf, err = Get("1,2,4")
+	if err != nil {
+		t.Errorf("failed to get manifests %v", err)
+	}
+	if !reflect.DeepEqual(mf.NS, corev1.Namespace{}) {
+		t.Errorf("should have an empty namespace when WithNamespace called")
+	}
+	if mf.DS.Namespace != "" {
+		t.Errorf("%q object namespace should be set to default", mf.DS.Kind)
 	}
 }

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -132,4 +132,12 @@ func TestGet(t *testing.T) {
 	if mf.DS.Namespace != "" {
 		t.Errorf("%q object namespace should be set to default", mf.DS.Kind)
 	}
+
+	mf, err = Get("1,2,4", WithName("foo"))
+	if err != nil {
+		t.Errorf("failed to get manifests %v", err)
+	}
+	if mf.DS.Name != "foo" {
+		t.Errorf("%q object name should be equal to foo", mf.DS.Kind)
+	}
 }

--- a/test/e2e/infrastructure/infrastructure.go
+++ b/test/e2e/infrastructure/infrastructure.go
@@ -85,7 +85,7 @@ func setup(ctx context.Context, c client.Client, ns string) error {
 		return err
 	}
 
-	mf, err := manifests.Get(ns, e2econfig.SharedCPUs())
+	mf, err := manifests.Get(e2econfig.SharedCPUs(), manifests.WithNewNamespace(ns))
 	if err != nil {
 		return err
 	}
@@ -114,7 +114,7 @@ func setup(ctx context.Context, c client.Client, ns string) error {
 }
 
 func teardown(ctx context.Context, c client.Client, ns string) error {
-	mf, err := manifests.Get(ns, e2econfig.SharedCPUs())
+	mf, err := manifests.Get(e2econfig.SharedCPUs(), manifests.WithNewNamespace(ns))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
We want to have the option to set/create the namespace and/or set the objects' names.
A good way to allow this flexibility is by using optional parameter functions.

When the client controls the name,
it can store the name and delete the objects without having the need to hold the objects themselves.
    
In our case for example we want to be able to
the node-plugin (delete the objects) without deleting the profile.
    
This can be done easily by specifying the name
of the objects we want to delete.
