### PR TITLE
DNM:nriplugin: env var for isolated cpus

### DIFF
--- a/pkg/deviceplugin/implementation.go
+++ b/pkg/deviceplugin/implementation.go
@@ -88,7 +88,8 @@ func (p pluginImp) Allocate(ctx context.Context, request *pluginapi.AllocateRequ
 	glog.V(4).Infof("Allocate called with %+v", request)
 	for range request.ContainerRequests {
 		containerResponse := &pluginapi.ContainerAllocateResponse{
-			Envs: map[string]string{"OPENSHIFT_MUTUAL_CPUS": p.mutualCpus.String()},
+			Envs: map[string]string{"OPENSHIFT_MUTUAL_CPUS": p.mutualCpus.String(),
+				"TEST1": "TEST2"},
 		}
 		response.ContainerResponses = append(response.ContainerResponses, containerResponse)
 	}

--- a/pkg/manifests/yamls/daemonset.yaml
+++ b/pkg/manifests/yamls/daemonset.yaml
@@ -17,9 +17,9 @@ spec:
             image: quay.io/titzhak/mixedcpus
             imagePullPolicy: Always
             command:
-              - /bin/mixedcpus
+              - /bin/mixedcpu
             args:
-              - --name=mixedcpus
+              - --name=mixedcpu
               - --idx=99
               - --v=4
               - --alsologtostderr

--- a/pkg/nriplugin/nriplugin.go
+++ b/pkg/nriplugin/nriplugin.go
@@ -31,7 +31,8 @@ import (
 )
 
 const (
-	milliCPUToCPU = 1000
+	IsolatedCPUsEnvVar = "OPENSHIFT_ISOLATED_CPUS"
+	milliCPUToCPU      = 1000
 )
 
 // Plugin nriplugin for mixed cpus
@@ -81,6 +82,12 @@ func (p *Plugin) CreateContainer(pod *api.PodSandbox, ctr *api.Container) (*api.
 		return adjustment, updates, nil
 	}
 	uniqueName := getCtrUniqueName(pod, ctr)
+	env := api.KeyValue{
+		Key:   IsolatedCPUsEnvVar,
+		Value: ctr.Linux.Resources.Cpu.Cpus,
+	}
+	adjustment.Env = []*api.KeyValue{&env}
+
 	glog.Infof("append mutual cpus to container %q", uniqueName)
 	err := setMutualCPUs(ctr, p.MutualCPUs, uniqueName)
 	if err != nil {

--- a/pkg/nriplugin/nriplugin_test.go
+++ b/pkg/nriplugin/nriplugin_test.go
@@ -71,6 +71,9 @@ func TestCreateContainer(t *testing.T) {
 				if tc.quota != lcpu.Quota.Value {
 					t.Fatalf("unexpected quota; want: %q, got: %q", tc.quota, lcpu.Quota.Value)
 				}
+				if ca.Env[0].Key != IsolatedCPUsEnvVar || ca.Env[0].Value != tc.cpuset {
+					t.Fatalf("failed to set isolated cpu env var: want: %q, got: %q", tc.cpuset, ca.Env[0].Value)
+				}
 			} else {
 				if ca.Linux != nil {
 					t.Fatalf("expected api.LinuxContainerAdjustment response to be nil")

--- a/test/e2e/config/config.go
+++ b/test/e2e/config/config.go
@@ -2,10 +2,20 @@ package config
 
 import "os"
 
+const defaultImageName = "registry.ci.openshift.org/ocp-kni/mixed-cpu-node-plugin:mixed-cpu-node-plugin"
+
 func SharedCPUs() string {
 	cpus, ok := os.LookupEnv("E2E_SHARED_CPUS")
 	if !ok {
 		return ""
 	}
 	return cpus
+}
+
+func Image() string {
+	image, ok := os.LookupEnv("E2E_IMAGE_NAME")
+	if !ok {
+		return defaultImageName
+	}
+	return image
 }

--- a/test/e2e/infrastructure/infrastructure.go
+++ b/test/e2e/infrastructure/infrastructure.go
@@ -180,4 +180,5 @@ func updateOpenshiftConfig(mf *manifests.Manifests) {
 	podSpec.Containers[0].SecurityContext = &corev1.SecurityContext{
 		Privileged: pointer.Bool(true),
 	}
+	podSpec.Containers[0].Image = e2econfig.Image()
 }

--- a/test/e2e/mixedcpus/mixedcpus.go
+++ b/test/e2e/mixedcpus/mixedcpus.go
@@ -147,7 +147,7 @@ var _ = Describe("Mixedcpus", func() {
 			isolatedCpusSet := e2ecpuset.MustParse(pod.Spec.Containers[0].Resources.Requests.Cpu().String())
 			out, err := pods.Exec(fxt.K8SCli, pod, []string{"/bin/printenv"})
 			Expect(err).ToNot(HaveOccurred())
-			klog.Infof("/bin/printenv %v", out)
+			klog.Infof("/bin/printenv %v", string(out))
 			Expect(out).ToNot(BeEmpty(), "%s environment variable was not found", nriplugin.IsolatedCPUsEnvVar)
 
 			envVar := strings.Trim(string(out), "\r\n")

--- a/test/e2e/mixedcpus/mixedcpus.go
+++ b/test/e2e/mixedcpus/mixedcpus.go
@@ -19,6 +19,7 @@ package mixedcpus
 import (
 	"context"
 	"fmt"
+	"github.com/openshift-kni/mixed-cpu-node-plugin/pkg/nriplugin"
 	"github.com/openshift-kni/mixed-cpu-node-plugin/test/e2e/fixture"
 	"strings"
 
@@ -140,6 +141,18 @@ var _ = Describe("Mixedcpus", func() {
 			sharedCpusFromEnv, err := cpuset.Parse(envVar)
 			Expect(err).ToNot(HaveOccurred(), "failed parse %q to cpuset", sharedCpusFromEnv)
 			Expect(sharedCpusSet.Equals(sharedCpusFromEnv)).To(BeTrue())
+		})
+
+		It("should contain OPENSHIFT_ISOLATED_CPUS environment variable", func() {
+			isolatedCpusSet := e2ecpuset.MustParse(pod.Spec.Containers[0].Resources.Requests.Cpu().String())
+			out, err := pods.Exec(fxt.K8SCli, pod, []string{"/bin/printenv", nriplugin.IsolatedCPUsEnvVar})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).ToNot(BeEmpty(), "%s environment variable was not found", nriplugin.IsolatedCPUsEnvVar)
+
+			envVar := strings.Trim(string(out), "\r\n")
+			isolaredCpusFromEnv, err := cpuset.Parse(envVar)
+			Expect(err).ToNot(HaveOccurred(), "failed parse %q to cpuset", isolaredCpusFromEnv)
+			Expect(isolatedCpusSet.Equals(isolaredCpusFromEnv)).To(BeTrue())
 		})
 	})
 

--- a/test/e2e/mixedcpus/mixedcpus.go
+++ b/test/e2e/mixedcpus/mixedcpus.go
@@ -145,8 +145,9 @@ var _ = Describe("Mixedcpus", func() {
 
 		It("should contain OPENSHIFT_ISOLATED_CPUS environment variable", func() {
 			isolatedCpusSet := e2ecpuset.MustParse(pod.Spec.Containers[0].Resources.Requests.Cpu().String())
-			out, err := pods.Exec(fxt.K8SCli, pod, []string{"/bin/printenv", nriplugin.IsolatedCPUsEnvVar})
+			out, err := pods.Exec(fxt.K8SCli, pod, []string{"/bin/printenv"})
 			Expect(err).ToNot(HaveOccurred())
+			klog.Infof("/bin/printenv %v", out)
 			Expect(out).ToNot(BeEmpty(), "%s environment variable was not found", nriplugin.IsolatedCPUsEnvVar)
 
 			envVar := strings.Trim(string(out), "\r\n")


### PR DESCRIPTION
Instead of having the need to derive the isolated cpus
from the complete cpuset minus the shared, let's add
a new env variable `OPENSHIFT_ISOLATED_CPUS` on which we
can obtain the the isloated cpu set directly.