### PR TITLE
naming: change mutual cpus to shared cpus

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -34,7 +34,7 @@ func main() {
 		glog.Fatalf("%v", err)
 	}
 
-	dp, err := deviceplugin.New(args.MutualCPUs)
+	dp, err := deviceplugin.New(args.SharedCPUs)
 	if err != nil {
 		glog.Fatalf("%v", err)
 	}
@@ -46,7 +46,7 @@ func parseArgs() *nriplugin.Args {
 	args := &nriplugin.Args{}
 	flag.StringVar(&args.PluginName, "name", "", "plugin name to register to NRI")
 	flag.StringVar(&args.PluginIdx, "idx", "", "plugin index to register to NRI")
-	flag.StringVar(&args.MutualCPUs, "mutual-cpus", "", "mutual cpus list")
+	flag.StringVar(&args.SharedCPUs, "shared-cpus", "", "shared cpus list")
 	flag.Parse()
 	return args
 }

--- a/deployment/kustomize/base/daemonset.yaml
+++ b/deployment/kustomize/base/daemonset.yaml
@@ -20,7 +20,7 @@ spec:
             args:
               - --name=mixedcpus
               - --idx=99
-              - --mutual-cpus=0
+              - --shared-cpus=0
               - --v=4
               - --alsologtostderr
             resources:

--- a/pkg/deviceplugin/deviceplugin.go
+++ b/pkg/deviceplugin/deviceplugin.go
@@ -26,37 +26,37 @@ import (
 )
 
 const (
-	MutualCPUResourceNamespace = "openshift.io"
-	MutualCPUResourceName      = "mutualcpu"
-	MutualCPUDeviceName        = MutualCPUResourceNamespace + "/" + MutualCPUResourceName
-	EnvVarName                 = "OPENSHIFT_MUTUAL_CPUS"
+	SharedCPUResourceNamespace = "openshift.io"
+	SharedCPUResourceName      = "sharedcpu"
+	SharedCPUDeviceName        = SharedCPUResourceNamespace + "/" + SharedCPUResourceName
+	EnvVarName                 = "OPENSHIFT_SHARED_CPUS"
 )
 
-type MutualCpu struct {
+type SharedCpu struct {
 	cpus cpuset.CPUSet
 }
 
-func (mc *MutualCpu) GetResourceNamespace() string {
-	return MutualCPUResourceNamespace
+func (mc *SharedCpu) GetResourceNamespace() string {
+	return SharedCPUResourceNamespace
 }
 
-func (mc *MutualCpu) Discover(pnl chan dpm.PluginNameList) {
-	pnl <- []string{MutualCPUResourceName}
+func (mc *SharedCpu) Discover(pnl chan dpm.PluginNameList) {
+	pnl <- []string{SharedCPUResourceName}
 }
 
-func (mc *MutualCpu) NewPlugin(s string) dpm.PluginInterface {
+func (mc *SharedCpu) NewPlugin(s string) dpm.PluginInterface {
 	return pluginImp{
-		mutualCpus: &mc.cpus,
+		sharedCpus: &mc.cpus,
 		update:     make(chan message),
 	}
 }
 
 func New(cpus string) (*dpm.Manager, error) {
-	mutualCpus, err := cpuset.Parse(cpus)
+	sharedCpus, err := cpuset.Parse(cpus)
 	if err != nil {
 		return nil, err
 	}
-	mc := &MutualCpu{cpus: mutualCpus}
+	mc := &SharedCpu{cpus: sharedCpus}
 	return dpm.NewManager(mc), nil
 }
 

--- a/pkg/deviceplugin/implementation.go
+++ b/pkg/deviceplugin/implementation.go
@@ -41,7 +41,7 @@ type message struct {
 }
 
 type pluginImp struct {
-	mutualCpus       *cpuset.CPUSet
+	sharedCpus       *cpuset.CPUSet
 	update           chan message
 	allocatedDevices int
 }
@@ -61,7 +61,7 @@ func (p pluginImp) ListAndWatch(empty *pluginapi.Empty, server pluginapi.DeviceP
 		u := <-p.update
 		p.allocatedDevices += u.requestedDevices
 		if p.allocatedDevices > devicesLimit {
-			glog.V(2).Infof("Warning: device limit has reached. can not populate more %q makeDevices", MutualCPUDeviceName)
+			glog.V(2).Infof("Warning: device limit has reached. can not populate more %q makeDevices", SharedCPUDeviceName)
 			continue
 		}
 		// check if more makeDevices are needed
@@ -88,7 +88,7 @@ func (p pluginImp) Allocate(ctx context.Context, request *pluginapi.AllocateRequ
 	glog.V(4).Infof("Allocate called with %+v", request)
 	for range request.ContainerRequests {
 		containerResponse := &pluginapi.ContainerAllocateResponse{
-			Envs: map[string]string{"OPENSHIFT_MUTUAL_CPUS": p.mutualCpus.String()},
+			Envs: map[string]string{"OPENSHIFT_SHARED_CPUS": p.sharedCpus.String()},
 		}
 		response.ContainerResponses = append(response.ContainerResponses, containerResponse)
 	}

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -139,7 +139,7 @@ func (mf *Manifests) ToObjects() []client.Object {
 }
 
 // SetSharedCPUs updates the container args under the
-// DaemonSet with a --mutual-cpus value.
+// DaemonSet with a --shared-cpus value.
 // It returns an error if the cpus are not a valid cpu set.
 func (mf *Manifests) SetSharedCPUs(cpus string) error {
 	set, err := cpuset.Parse(cpus)
@@ -150,12 +150,12 @@ func (mf *Manifests) SetSharedCPUs(cpus string) error {
 	var newArgs []string
 	for _, arg := range cnt.Args {
 		keyAndValue := strings.Split(arg, "=")
-		if keyAndValue[0] == "--mutual-cpus" {
+		if keyAndValue[0] == "--shared-cpus" {
 			continue
 		}
 		newArgs = append(newArgs, arg)
 	}
-	newArgs = append(newArgs, fmt.Sprintf("--mutual-cpus=%s", set.String()))
+	newArgs = append(newArgs, fmt.Sprintf("--shared-cpus=%s", set.String()))
 	cnt.Args = newArgs
 	return nil
 }

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -67,7 +67,7 @@ func TestSetSharedCPUs(t *testing.T) {
 		cnt := &mf.DS.Spec.Template.Spec.Containers[0]
 		for _, arg := range cnt.Args {
 			keyAndValue := strings.Split(arg, "=")
-			if keyAndValue[0] == "--mutual-cpus" {
+			if keyAndValue[0] == "--shared-cpus" {
 				// we know the format is correct, otherwise Get() would return with an error
 				gotCPUset, _ = cpuset.Parse(keyAndValue[1])
 				break

--- a/pkg/nriplugin/nriplugin_test.go
+++ b/pkg/nriplugin/nriplugin_test.go
@@ -35,7 +35,7 @@ const (
 func TestCreateContainer(t *testing.T) {
 	testCases := []struct {
 		name       string
-		mutualCPUs cpuset.CPUSet
+		sharedCPUs cpuset.CPUSet
 		sb         *api.PodSandbox
 		ctr        *api.Container
 		lres       *api.LinuxResources
@@ -44,7 +44,7 @@ func TestCreateContainer(t *testing.T) {
 	}{
 		{
 			name:       "pod without annotation",
-			mutualCPUs: e2ecpuset.MustParse(sampleCPUs),
+			sharedCPUs: e2ecpuset.MustParse(sampleCPUs),
 			sb:         makePodSandbox("test-sb"),
 			ctr:        makeContainer("test-ctr", withLinuxResources("1,2", 20000)),
 			lres:       nil,
@@ -57,7 +57,7 @@ func TestCreateContainer(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			p := &Plugin{
 				Stub:       nil,
-				MutualCPUs: &tc.mutualCPUs,
+				SharedCPUs: &tc.sharedCPUs,
 			}
 			ca, _, err := p.CreateContainer(tc.sb, tc.ctr)
 			if err != nil {


### PR DESCRIPTION
This name is more intuitive and its the one that will used across the code base, documentation, glossary, etc.