### PR TITLE
CNFCERT-1258: Add kustomize validation check

### DIFF
--- a/.github/workflows/kustomize-validation.yml
+++ b/.github/workflows/kustomize-validation.yml
@@ -1,0 +1,48 @@
+name: Kustomize Validation
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  kustomize-validation:
+    name: Validate Kustomization Files
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Kustomize
+        run: |
+          # Download with retries to prevent flaky CI failures
+          MAX_ATTEMPTS=3
+          ATTEMPT=1
+          
+          while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
+            echo "Attempt $ATTEMPT of $MAX_ATTEMPTS: Downloading kustomize install script..."
+            if curl -fsSL --retry 3 --retry-delay 2 "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash; then
+              echo "Successfully downloaded and installed kustomize"
+              break
+            else
+              echo "Failed to install kustomize"
+              if [ $ATTEMPT -eq $MAX_ATTEMPTS ]; then
+                echo "All attempts failed"
+                exit 1
+              fi
+              echo "Waiting 5 seconds before retry..."
+              sleep 5
+              ATTEMPT=$((ATTEMPT + 1))
+            fi
+          done
+          
+          sudo mv kustomize /usr/local/bin/
+          kustomize version
+
+      - name: Validate Kustomization Files
+        run: make test-kustomize
+
+

--- a/Makefile
+++ b/Makefile
@@ -169,6 +169,9 @@ test-unit:
 test-e2e: build-e2e
 	hack/e2e-run-test.sh $(E2E_SHARED_CPUS) $(E2E_SETUP) $(E2E_TEARDOWN)
 
+test-kustomize:
+	hack/test-kustomize.sh
+
 
 deps-update:
 	$(GO_CMD) mod tidy && $(GO_CMD) mod vendor

--- a/hack/test-kustomize.sh
+++ b/hack/test-kustomize.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Directories that require external kustomize plugins
+# These plugins are distributed via Red Hat container images and are designed to run
+# in OpenShift ArgoCD with ACM/MCE installed.
+#
+# Currently, this repository does not use any external plugins (e.g., PolicyGenerator,
+# ClusterInstance, SiteConfig, PolicyGenTemplate), so this array is empty.
+# If external plugins are added in the future, their directories should be listed here.
+EXCLUDED_DIRS=()
+
+# Check if kustomize is installed
+if ! command -v kustomize &> /dev/null; then
+    echo -e "${RED}ERROR: kustomize is not installed${NC}"
+    echo ""
+    echo "Please install kustomize to run this check:"
+    echo "  - macOS: brew install kustomize"
+    echo "  - Linux: curl -s \"https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh\" | bash"
+    echo "  - Manual: https://kubectl.docs.kubernetes.io/installation/kustomize/"
+    echo ""
+    exit 1
+fi
+
+echo "Checking all kustomization.yaml files can build successfully..."
+echo ""
+
+ERRORS=0
+CHECKED=0
+SKIPPED=0
+
+# Helper function to check if directory should be excluded
+is_excluded() {
+    local dir="$1"
+    for excluded in "${EXCLUDED_DIRS[@]}"; do
+        if [ "$dir" = "$excluded" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Find all kustomization.yaml files
+kustomize_files=()
+while IFS= read -r file; do
+    kustomize_files+=("$file")
+done < <(find . -name 'kustomization.yaml' -not -path '*/vendor/*' -not -path '*/.git/*' | sort)
+
+if [ ${#kustomize_files[@]} -eq 0 ]; then
+    echo -e "${YELLOW}WARNING: No kustomization.yaml files found${NC}"
+    exit 0
+fi
+
+for kustomize_file in "${kustomize_files[@]}"; do
+    dir=$(dirname "$kustomize_file")
+    echo -n "  $dir: "
+    
+    # Check if this directory requires external plugins
+    if is_excluded "$dir"; then
+        echo -e "${BLUE}SKIPPED${NC} (requires external plugins)"
+        SKIPPED=$((SKIPPED + 1))
+        continue
+    fi
+    
+    # Try to build the kustomization
+    if kustomize build "$dir" > /dev/null 2>&1; then
+        echo -e "${GREEN}OK${NC}"
+        CHECKED=$((CHECKED + 1))
+    else
+        echo -e "${RED}FAILED${NC}"
+        echo -e "${YELLOW}    Error details:${NC}"
+        kustomize build "$dir" 2>&1 | sed 's/^/    /'
+        echo ""
+        ERRORS=$((ERRORS + 1))
+        CHECKED=$((CHECKED + 1))
+    fi
+done
+
+echo ""
+if [ $SKIPPED -gt 0 ]; then
+    echo "Summary: Checked $CHECKED kustomization.yaml files, skipped $SKIPPED (require external plugins)"
+else
+    echo "Summary: Checked $CHECKED kustomization.yaml files"
+fi
+
+if [[ $ERRORS -eq 0 ]]; then
+    echo -e "${GREEN}All kustomization files validated successfully!${NC}"
+    exit 0
+else
+    echo -e "${RED}$ERRORS kustomization file(s) failed validation${NC}"
+    exit 1
+fi
+
+


### PR DESCRIPTION
Similar to: https://github.com/openshift-kni/telco-reference/pull/433

Changes:
- Adds a quick PR check that attempts to `kustomize build` appropriate files.  Only runs against `main`.
- Adds a make path for `make test-kustomize` which runs the script.  Users can run this locally as well as there are safeguards to ensure `kustomize` exists first.
- Skips YAMLs that might require external plugins.  See `EXCLUDED_DIRS`.

Example run:

```
$ make test-kustomize 
Checking all kustomization.yaml files can build successfully...

  ./deployment/kustomize/base: OK
  ./deployment/kustomize/overlays/default: OK
  ./deployment/kustomize/overlays/openshift: OK
  ./deployment/kustomize/overlays/openshift/rbac: OK

Summary: Checked 4 kustomization.yaml files
All kustomization files validated successfully!
```